### PR TITLE
Adding Kempston support

### DIFF
--- a/drivers/input.asm
+++ b/drivers/input.asm
@@ -1,0 +1,25 @@
+    MODULE Input
+
+read:
+    call Keyboard.inkey
+    and a : ret nz
+
+    in a, ($1f) // port A
+    call Joystick.readJoystick
+    and a : ret nz
+
+    in a, ($37) // port B
+    call Joystick.readJoystick
+
+    ret
+
+waitForButtonUp:
+    call Keyboard.waitForKeyUp
+
+    in a, ($1f) // port A
+    call Joystick.waitForButtonUp
+
+    in a, ($37) // port B
+    call Joystick.waitForButtonUp
+
+    ENDMODULE

--- a/drivers/joystick.asm
+++ b/drivers/joystick.asm
@@ -1,0 +1,66 @@
+   MODULE Joystick
+
+JOY_BUTTON_A_BIT = 6
+JOY_BUTTON_B_BIT = 4
+JOY_UP_BIT = 3
+JOY_DOWN_BIT = 2
+JOY_LEFT_BIT = 1
+JOY_RIGHT_BIT = 0
+
+waitForButtonUp:
+   in a, ($1f) // port A
+   call readJoystickPort
+   and a : jr nz, waitForButtonUp
+
+   in a, ($37) // port B
+   call readJoystickPort
+   and a : jr nz, waitForButtonUp
+
+   ret
+
+readJoystick:
+   in a, ($1f) // port A
+   call readJoystickPort
+   and a : ret nz
+
+   in a, ($37) // port B
+   call readJoystickPort
+   ret
+
+readJoystickPort: // translate to KEY_* in register `a`
+   bit JOY_UP_BIT, a : jp nz, .joyUp
+   bit JOY_DOWN_BIT, a : jp nz, .joyDown
+   bit JOY_LEFT_BIT, a : jp nz, .joyLeft
+   bit JOY_RIGHT_BIT, a : jp nz, .joyRight
+   bit JOY_BUTTON_A_BIT, a : jp nz, .joyBack
+   bit JOY_BUTTON_B_BIT, a : jp nz, .joyNavigate
+.nothing:
+   xor a
+   ret
+
+.joyUp
+   bit JOY_DOWN_BIT, a : jp nz, .nothing // not connected if up and down are high
+   ld a, Keyboard.KEY_UP
+   ret
+
+.joyDown
+   ld a, Keyboard.KEY_DOWN
+   ret
+
+.joyLeft
+   ld a, Keyboard.KEY_LEFT
+   ret
+
+.joyRight
+   ld a, Keyboard.KEY_RIGHT
+   ret
+
+.joyNavigate
+   ld a, 13
+   ret
+
+.joyBack:
+   ld a, 'b'
+   ret
+
+   ENDMODULE

--- a/main.asm
+++ b/main.asm
@@ -18,6 +18,8 @@ SLOT1_PAGE = 17
 
    include "drivers/utils.asm"
    include "drivers/keyboard.asm"
+   include "drivers/joystick.asm"
+   include "drivers/input.asm"
    include "drivers/tile-driver.asm"
    include "engine/engine.asm"
    include "utils/limitedstring.asm"

--- a/player/vortex-processor.asm
+++ b/player/vortex-processor.asm
@@ -1,17 +1,18 @@
     MODULE VortexProcessor
 play:
-    call Keyboard.waitForKeyUp
+    call Input.waitForButtonUp
 
     ld hl, message : call DialogBox.msgNoWait
 
     ld hl, buffer  : call VTPL.INIT
 .loop
     halt : di : call VTPL.PLAY : ei
-    xor a : in a, (#fe) : cpl : and 31 : jp nz, .stop
+    call Input.read
+    and a : jp nz, .stop
     ld a, (VTPL.SETUP) : rla : jr nc, .loop 
 .stop
     call VTPL.MUTE
-    call Keyboard.waitForKeyUp
+    call Input.waitForButtonUp
     ret
 
 message db "Press key to stop...", 0

--- a/render/dialogbox.asm
+++ b/render/dialogbox.asm
@@ -3,7 +3,7 @@
 msgBox:
     push hl
     call drawBox
-    call Keyboard.waitForKeyUp
+    call Input.waitForButtonUp
     pop hl
     call TextMode.printZ
     ld b, 150

--- a/render/gopher-page.asm
+++ b/render/gopher-page.asm
@@ -28,7 +28,7 @@ workLoop:
     dup WAIT_FRAMES
     halt 
     edup
-    call Keyboard.inkey
+    call Input.read
     and a : jp z, workLoop
 
     cp 'a' : jp z, cursorDown

--- a/render/plaintext.asm
+++ b/render/plaintext.asm
@@ -19,7 +19,7 @@ plainTextLoop:
     dup WAIT_FRAMES
     halt 
     edup
-    call Keyboard.inkey
+    call Input.read
     and a : jr z, plainTextLoop
     
     ; Down

--- a/screen-viewer/index.asm
+++ b/screen-viewer/index.asm
@@ -1,6 +1,6 @@
     MODULE ScreenViewer
 display:
-    call Keyboard.waitForKeyUp
+    call Input.waitForButtonUp
 
     NextRegRead Slot_6_Reg : ld (SLOT6), a
     NextRegRead Slot_7_Reg : ld (SLOT7), a
@@ -10,7 +10,8 @@ display:
     ld hl, buffer, de, #c000, bc, 6912 : ldir
     call forceZXMode
 .wait2
-    xor a : in a, (#fe) : cpl : and 31 : jr z, .wait2
+    call Input.read
+    and a : jr z, .wait2
 
     call backToTileMode
     ld a, (SLOT6) : nextreg Slot_6_Reg, a


### PR DESCRIPTION
## Reason
I'd love to use this app using my wireless controller rather than reaching into the keyboard. I realise I could in theory map one of the joystick ports to be the key equivalents, but I don't want to tweak my joystick config, I want to keep my joystick port as a Kempston controller but still use this app without setup.

## The Changes
This PR adds support for Kempston joystick control (both port A and port B).

It does this by introducing a redirection. It adds an `Input` and `Joystick` module.

The `Input` module is a 1:1 mapping for the `Keyboard` module, replacing `Keyboard.inkey` with `Input.read`, and `Keyboard.waitForKeyUp` with `Input.waitForKeyUp`. The return values from the called routines doesn't change.

However this module also checks the new `Joystick` driver for input if there is no key pressed. That method returns the equivalent keys for the directional controls, `enter` for the primary fire button, and `b` for the secondary button to match NextZXOS "back" behaviour.